### PR TITLE
Remove authentication and authorization from CarsController

### DIFF
--- a/app/controllers/api/v1/cars_controller.rb
+++ b/app/controllers/api/v1/cars_controller.rb
@@ -1,6 +1,4 @@
 class Api::V1::CarsController < ApplicationController
-  before_action :authenticate_user
-  load_and_authorize_resource
   # GET /cars
   def index
     @cars = Car.all.order(created_at: :desc)


### PR DESCRIPTION
On this branch, I removed authentication and authorization from the carsController, in order to allow unregistered users to access the cars information.